### PR TITLE
fix PluginTemplateExtension model registration for netbox 4.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ exit
 
 ## Supported versions
 
-The current version of the  `netbox-plugin-mclag` plugin has been developed for Netbox 4.2. and is not supported on older versions.
+The current version of the  `netbox-plugin-mclag` plugin has been developed for Netbox 4.3. and is not supported on older versions.
 
 The plugin has been developed for Python 3.12.3, but I expect it to work with any Python version supported by Netbox.
 

--- a/netbox_plugin_mclag/template_content.py
+++ b/netbox_plugin_mclag/template_content.py
@@ -4,7 +4,7 @@ from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 
 
 class McLagInterfaceExtensions(PluginTemplateExtension):
-    model = "dcim.interface"
+    models = ["dcim.interface"]
 
     def buttons(self):
         interface = self.context["object"]
@@ -33,7 +33,7 @@ class McLagInterfaceExtensions(PluginTemplateExtension):
 
 
 class McLagDeviceExtensions(PluginTemplateExtension):
-    model = "dcim.device"
+    models = ["dcim.device"]
 
     def buttons(self):
         device = self.context["object"]


### PR DESCRIPTION
Since the plugin currently does not have code to distinguish the netbox version, I updated the minimum version to 4.3 in the readme. If you so wish, we could alternatively introduce code like this: https://github.com/h3po/netbox_ipcalculator/commit/ece9bbf2d11ea6194e82170b1ba0f3e42d416c77